### PR TITLE
Remove old test file and focus on campaign structure

### DIFF
--- a/src/campaign_reader/models.py
+++ b/src/campaign_reader/models.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+from pathlib import Path
+
+@dataclass
+class CampaignSegment:
+    """Represents a segment in a campaign."""
+    id: str
+    sequence_number: int
+    recorded_at: datetime
+    video_path: str
+    analytics_file_pattern: str
+    _extracted_path: Optional[Path] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'CampaignSegment':
+        """Create a segment from a dictionary."""
+        return cls(
+            id=data['id'],
+            sequence_number=data['sequenceNumber'],
+            recorded_at=datetime.fromtimestamp(data['recordedAt'] / 1000.0),
+            video_path=data['videoPath'],
+            analytics_file_pattern=data['analyticsFilePattern']
+        )
+
+    def get_video_path(self) -> Optional[Path]:
+        """Get the path to the extracted video file."""
+        if self._extracted_path:
+            return self._extracted_path / 'video.mp4'
+        return None
+
+    def get_analytics_path(self) -> Optional[Path]:
+        """Get the path to the analytics directory."""
+        if self._extracted_path:
+            return self._extracted_path / 'analytics'
+        return None
+
+@dataclass
+class Campaign:
+    """Represents a campaign with metadata and segments."""
+    id: str
+    name: str
+    created_at: datetime
+    description: str
+    segments: List[CampaignSegment]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'Campaign':
+        """Create a campaign from a dictionary."""
+        return cls(
+            id=data['id'],
+            name=data['name'],
+            created_at=datetime.fromtimestamp(data['createdAt'] / 1000.0),
+            description=data['description'],
+            segments=[CampaignSegment.from_dict(seg) for seg in data['segments']]
+        )
+
+    def get_segment(self, segment_id: str) -> Optional[CampaignSegment]:
+        """Get a segment by its ID."""
+        for segment in self.segments:
+            if segment.id == segment_id:
+                return segment
+        return None
+
+    def get_ordered_segments(self) -> List[CampaignSegment]:
+        """Get segments ordered by sequence number."""
+        return sorted(self.segments, key=lambda x: x.sequence_number)

--- a/tests/test_campaign_reader.py
+++ b/tests/test_campaign_reader.py
@@ -1,0 +1,155 @@
+import os
+import json
+import pytest
+import tempfile
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from campaign_reader import CampaignReader, CampaignZipError
+
+@pytest.fixture
+def sample_campaign_data():
+    """Sample campaign metadata."""
+    return {
+        "id": "060953aa-7baf-435b-aee2-2faaeb438aaf",
+        "name": "Test drive around Lees Summit",
+        "createdAt": 1733434689359,
+        "description": "Driving around Lees Summit MO",
+        "segments": [
+            {
+                "id": "7e0226fd-2903-4d4b-b399-f103e9063e06",
+                "sequenceNumber": 0,
+                "recordedAt": 1733434791634,
+                "videoPath": "/data/video.mp4",
+                "analyticsFilePattern": "/data/analytics_{}"
+            },
+            {
+                "id": "11eb4c5e-cc52-4836-b5a6-f68f64c0e1b9",
+                "sequenceNumber": 1,
+                "recordedAt": 1733435091748,
+                "videoPath": "/data/video.mp4",
+                "analyticsFilePattern": "/data/analytics_{}"
+            }
+        ]
+    }
+
+@pytest.fixture
+def sample_analytics_data():
+    """Sample analytics data."""
+    return [
+        {"timestamp": 1733434791634, "data": "sample1"},
+        {"timestamp": 1733434791635, "data": "sample2"}
+    ]
+
+@pytest.fixture
+def campaign_zip(sample_campaign_data, sample_analytics_data):
+    """Create a temporary campaign zip file with test content."""
+    with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
+        with zipfile.ZipFile(temp_zip.name, 'w') as zf:
+            # Add campaign metadata
+            zf.writestr('metadata/campaign.json', json.dumps(sample_campaign_data))
+            
+            # Add segment files
+            for segment in sample_campaign_data['segments']:
+                # Add video file
+                segment_path = f"segments/{segment['id']}/video.mp4"
+                zf.writestr(segment_path, b'fake video data')
+                
+                # Add analytics files
+                analytics_path = f"segments/{segment['id']}/analytics/analytics.json"
+                zf.writestr(analytics_path, json.dumps(sample_analytics_data))
+                
+                # Add additional analytics files
+                for i in range(1, 3):
+                    analytics_path = f"segments/{segment['id']}/analytics/analytics_{i}.json"
+                    zf.writestr(analytics_path, json.dumps(sample_analytics_data))
+        
+        yield temp_zip.name
+        # Cleanup
+        os.unlink(temp_zip.name)
+
+def test_campaign_metadata_loading(campaign_zip):
+    """Test loading campaign metadata."""
+    with CampaignReader(campaign_zip) as reader:
+        campaign = reader.get_campaign_metadata()
+        assert campaign.id == "060953aa-7baf-435b-aee2-2faaeb438aaf"
+        assert campaign.name == "Test drive around Lees Summit"
+        assert isinstance(campaign.created_at, datetime)
+        assert campaign.description == "Driving around Lees Summit MO"
+        assert len(campaign.segments) == 2
+
+def test_segment_ordering(campaign_zip):
+    """Test segment ordering."""
+    with CampaignReader(campaign_zip) as reader:
+        segments = reader.get_segments()
+        assert len(segments) == 2
+        assert segments[0].sequence_number == 0
+        assert segments[1].sequence_number == 1
+        assert segments[0].id == "7e0226fd-2903-4d4b-b399-f103e9063e06"
+
+def test_segment_access(campaign_zip):
+    """Test accessing individual segments."""
+    with CampaignReader(campaign_zip) as reader:
+        segment = reader.get_segment("7e0226fd-2903-4d4b-b399-f103e9063e06")
+        assert segment is not None
+        assert segment.sequence_number == 0
+        assert isinstance(segment.recorded_at, datetime)
+        
+        # Test non-existent segment
+        assert reader.get_segment("non-existent") is None
+
+def test_segment_files_access(campaign_zip):
+    """Test accessing segment files."""
+    with CampaignReader(campaign_zip) as reader:
+        segment = reader.get_segment("7e0226fd-2903-4d4b-b399-f103e9063e06")
+        
+        # Check video path
+        video_path = segment.get_video_path()
+        assert video_path is not None
+        assert video_path.exists()
+        assert video_path.name == "video.mp4"
+        
+        # Check analytics path
+        analytics_path = segment.get_analytics_path()
+        assert analytics_path is not None
+        assert analytics_path.exists()
+        assert analytics_path.is_dir()
+
+def test_analytics_loading(campaign_zip):
+    """Test loading analytics data."""
+    with CampaignReader(campaign_zip) as reader:
+        segment_id = "7e0226fd-2903-4d4b-b399-f103e9063e06"
+        analytics = reader.get_segment_analytics(segment_id)
+        
+        # We have 3 files with 2 entries each
+        assert len(analytics) == 6
+        assert all(isinstance(entry["timestamp"], int) for entry in analytics)
+
+def test_invalid_segment_analytics(campaign_zip):
+    """Test error handling for invalid segment analytics."""
+    with CampaignReader(campaign_zip) as reader:
+        with pytest.raises(CampaignZipError):
+            reader.get_segment_analytics("non-existent")
+
+def test_segment_iteration(campaign_zip):
+    """Test iterating through segments."""
+    with CampaignReader(campaign_zip) as reader:
+        segments = list(reader.iter_segments())
+        assert len(segments) == 2
+        assert [seg.sequence_number for seg in segments] == [0, 1]
+
+def test_cleanup(campaign_zip):
+    """Test cleanup of extracted files."""
+    extracted_paths = []
+    with CampaignReader(campaign_zip) as reader:
+        # Store paths before cleanup
+        segment = reader.get_segment("7e0226fd-2903-4d4b-b399-f103e9063e06")
+        video_path = segment.get_video_path()
+        analytics_path = segment.get_analytics_path()
+        extracted_paths.extend([video_path, analytics_path])
+        
+        # Verify files exist
+        assert all(path.exists() for path in extracted_paths if path is not None)
+    
+    # After context manager exits, verify cleanup
+    assert not any(path.exists() for path in extracted_paths if path is not None)


### PR DESCRIPTION
Now that we're focusing on campaign-specific functionality, remove the old test file that was testing basic zip functionality.

Changes:
- Remove tests/test_reader.py as we're now testing campaign functionality in test_campaign_reader.py
- Keep focus on implementing proper campaign structure without worrying about backward compatibility yet

This allows us to focus on getting the campaign structure implementation right first.