### PR TITLE
Fix sequential frame extraction bug when sample_rate equals video fps

### DIFF
--- a/examples/extraction.py
+++ b/examples/extraction.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 
 import cv2
@@ -7,12 +8,12 @@ from campaign_reader import CampaignReader
 from campaign_reader.analytics import AnalyticsAggregator
 
 
-def load_campaign(name):
+def load_campaign(campaign_path, sample_rate, output_dir):
 
-    output_dir = Path("./output")
+    output_dir = Path(output_dir)
     output_dir.mkdir(exist_ok=True)
 
-    with CampaignReader(name, "./campaign") as reader:
+    with CampaignReader(campaign_path, "./campaign") as reader:
         campaign = reader.get_campaign_metadata()
         print(f"Campaign Name: {campaign.name}")
         print(f"Campaign Description: {campaign.description}")
@@ -45,7 +46,7 @@ def load_campaign(name):
         print(f"Format: {metadata['format']}")
 
         df = segment.process_frames(
-            sample_rate=.5,  # 5 frames per second
+            sample_rate=sample_rate,
             output_dir=output_dir
         )
         print(f"Extracted {len(df)} frames")
@@ -70,8 +71,40 @@ def load_campaign(name):
                 print(f"Frame file not found: {frame_path}")
 
 
-# Press the green button in the gutter to run the script.
-if __name__ == '__main__':
-    load_campaign('/Users/zikomofields/Downloads/Lake Lotawana HOA Roads_1733949339302.zip')
+def main():
+    parser = argparse.ArgumentParser(
+        description='Extract frames from campaign video with analytics data',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    
+    parser.add_argument(
+        'campaign_path',
+        help='Path to the campaign zip file'
+    )
+    
+    parser.add_argument(
+        '--sample-rate', '-s',
+        type=float,
+        default=30.0,
+        help='Frame extraction sample rate (frames per second)'
+    )
+    
+    parser.add_argument(
+        '--output-dir', '-o',
+        type=str,
+        default='./output',
+        help='Output directory for extracted frames'
+    )
+    
+    args = parser.parse_args()
+    
+    print(f"Processing campaign: {args.campaign_path}")
+    print(f"Sample rate: {args.sample_rate} fps")
+    print(f"Output directory: {args.output_dir}")
+    print("-" * 50)
+    
+    load_campaign(args.campaign_path, args.sample_rate, args.output_dir)
 
-# See PyCharm help at https://www.jetbrains.com/help/pycharm/
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
Fixes a critical bug in the sequential frame extraction method where only 1 frame would be extracted when the sample rate matched the video frame rate (e.g., 30fps video sampled at 30fps).

## Problem
When `sample_rate == video_fps`, multiple consecutive timestamps mapped to the same frame number due to `int(timestamp * fps)` calculation. The sequential extraction logic couldn't handle these duplicate target frame numbers, causing it to stop after extracting only the first frame.

## Solution
- Modified `_next_sequential()` method in `FrameIterator` to detect when the current frame position has exceeded the target frame number
- Added logic to seek back to the target frame when duplicate frame numbers occur
- Maintains the performance benefits of sequential reading while properly handling edge cases

## Testing Results
- ✅ **sample_rate=30fps**: Now correctly extracts **5985 frames** (was 1 frame)
- ✅ **sample_rate=29fps**: Continues working correctly (5785 frames) 
- ✅ **All existing tests pass**: No regressions introduced

## Additional Improvements
Enhanced the extraction example script with:
- **Argparse support** for better CLI experience
- **Configurable parameters**: campaign path, sample rate, output directory
- **Help documentation** with default values
- **Improved usability** for testing different scenarios

## Usage Example
```bash
# Use defaults (30 fps, ./output)
python examples/extraction.py /path/to/campaign.zip

# Specify custom sample rate and output
python examples/extraction.py /path/to/campaign.zip -s 25 -o ./my_frames
```

## Files Changed
- `src/campaign_reader/video.py`: Fixed sequential extraction logic
- `examples/extraction.py`: Added argparse and improved CLI interface

🤖 Generated with [Claude Code](https://claude.ai/code)