### PR TITLE
feat: add product field to campaign metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ campaign.zip
   "name": "Test Campaign",
   "createdAt": 1733434689359,
   "description": "Campaign description",
+  "product": "ViaSight Pro",
   "segments": [
     {
       "id": "7e0226fd-2903-4d4b-b399-f103e9063e06",

--- a/examples/extraction.py
+++ b/examples/extraction.py
@@ -17,6 +17,7 @@ def load_campaign(campaign_path, sample_rate, output_dir):
         campaign = reader.get_campaign_metadata()
         print(f"Campaign Name: {campaign.name}")
         print(f"Campaign Description: {campaign.description}")
+        print(f"Campaign Product: {campaign.product}")
         print(f"Campaign Created At: {campaign.created_at}")
 
         segment = reader.get_segments()[0]

--- a/src/campaign_reader/models.py
+++ b/src/campaign_reader/models.py
@@ -149,6 +149,7 @@ class Campaign:
     created_at: datetime
     description: str
     segments: List[CampaignSegment]
+    product: str
 
     @classmethod
     def from_dict(cls, data: dict) -> 'Campaign':
@@ -158,7 +159,8 @@ class Campaign:
             name=data['name'],
             created_at=datetime.fromtimestamp(data['createdAt'] / 1000.0),
             description=data['description'],
-            segments=[CampaignSegment.from_dict(seg) for seg in data['segments']]
+            segments=[CampaignSegment.from_dict(seg) for seg in data['segments']],
+            product=data.get('product', '')
         )
 
     def get_segment(self, segment_id: str) -> Optional[CampaignSegment]:

--- a/tests/test_campaign_reader.py
+++ b/tests/test_campaign_reader.py
@@ -17,6 +17,7 @@ def sample_campaign_data():
         "name": "Test drive around Lees Summit",
         "createdAt": 1733434689359,
         "description": "Driving around Lees Summit MO",
+        "product": "ViaSight Pro",
         "segments": [
             {
                 "id": "7e0226fd-2903-4d4b-b399-f103e9063e06",


### PR DESCRIPTION
## Summary
- Add `product` field to Campaign dataclass with backward compatibility (defaults to empty string)
- Update test fixtures to include product field
- Update README documentation with product field in metadata format example
- Add product display to extraction.py example script

## Test plan
- [ ] Run existing test suite to ensure backward compatibility
- [ ] Verify that campaigns without product field still load correctly (uses empty string default)
- [ ] Verify that campaigns with product field load and display the value properly
- [ ] Review documentation changes for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)