### PR TITLE
chore: bump version to 0.3.0 and add product field to campaign metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ campaign.zip
   "name": "Test Campaign",
   "createdAt": 1733434689359,
   "description": "Campaign description",
+  "product": "ViaSight Pro",
   "segments": [
     {
       "id": "7e0226fd-2903-4d4b-b399-f103e9063e06",

--- a/examples/extraction.py
+++ b/examples/extraction.py
@@ -17,6 +17,7 @@ def load_campaign(campaign_path, sample_rate, output_dir):
         campaign = reader.get_campaign_metadata()
         print(f"Campaign Name: {campaign.name}")
         print(f"Campaign Description: {campaign.description}")
+        print(f"Campaign Product: {campaign.product}")
         print(f"Campaign Created At: {campaign.created_at}")
 
         segment = reader.get_segments()[0]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='campaign-reader',
-    version='0.1.0',
+    version='0.3.0',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     install_requires=[

--- a/src/campaign_reader/models.py
+++ b/src/campaign_reader/models.py
@@ -149,6 +149,7 @@ class Campaign:
     created_at: datetime
     description: str
     segments: List[CampaignSegment]
+    product: str
 
     @classmethod
     def from_dict(cls, data: dict) -> 'Campaign':
@@ -158,7 +159,8 @@ class Campaign:
             name=data['name'],
             created_at=datetime.fromtimestamp(data['createdAt'] / 1000.0),
             description=data['description'],
-            segments=[CampaignSegment.from_dict(seg) for seg in data['segments']]
+            segments=[CampaignSegment.from_dict(seg) for seg in data['segments']],
+            product=data.get('product', '')
         )
 
     def get_segment(self, segment_id: str) -> Optional[CampaignSegment]:

--- a/tests/test_campaign_reader.py
+++ b/tests/test_campaign_reader.py
@@ -17,6 +17,7 @@ def sample_campaign_data():
         "name": "Test drive around Lees Summit",
         "createdAt": 1733434689359,
         "description": "Driving around Lees Summit MO",
+        "product": "ViaSight Pro",
         "segments": [
             {
                 "id": "7e0226fd-2903-4d4b-b399-f103e9063e06",


### PR DESCRIPTION
## Summary
- Add `product` field to Campaign metadata model with backward compatibility
- Update README.md and example code to demonstrate the new field
- Bump version from 0.1.0 to 0.3.0 to reflect this enhancement

## Changes
- Added `product` field to `Campaign` dataclass in `models.py`
- Updated `from_dict` method with `data.get('product', '')` for backward compatibility
- Updated documentation in README.md with product field example
- Updated `examples/extraction.py` to print the product field
- Added product field to test fixtures

## Test plan
- [x] Existing tests pass (backward compatibility maintained)
- [x] New test fixtures include product field
- [x] Example code runs successfully with new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)