### PR TITLE
fix: handle NaN coordinates and correct datetime unit in spatial stats

### DIFF
--- a/examples/extraction.py
+++ b/examples/extraction.py
@@ -36,7 +36,7 @@ def load_campaign(campaign_path, sample_rate, output_dir):
         print(f"Duration: {summary['temporal']['total_duration']:.2f} seconds")
 
         # Aggregate data by time interval
-        resampled = aggregator.aggregate_by_interval('5S')  # 5-second intervals
+        resampled = aggregator.aggregate_by_interval('5s')  # 5-second intervals
         print("\nIMU Statistics by 5-second intervals:")
         print(resampled['linear_acceleration_z'].describe())
 

--- a/src/campaign_reader/analytics/aggregation.py
+++ b/src/campaign_reader/analytics/aggregation.py
@@ -31,7 +31,7 @@ class AnalyticsAggregator:
         """Ensures datetime column exists in the DataFrame."""
         if 'datetime' not in self.df.columns:
             if not isinstance(self.df['systemTime'].iloc[0], pd.Timestamp):
-                self.df['datetime'] = pd.to_datetime(self.df['systemTime'].astype(float), unit='ms')
+                self.df['datetime'] = pd.to_datetime(self.df['systemTime'].astype(float), unit='s')
             else:
                 self.df['datetime'] = self.df['systemTime']
 
@@ -77,15 +77,16 @@ class AnalyticsAggregator:
 
         self._ensure_datetime()
 
-        # Calculate distances between consecutive points
-        coords = list(zip(self.df['latitude'], self.df['longitude']))
+        # Calculate distances between consecutive points, dropping NaN coordinates
+        valid = self.df.dropna(subset=['latitude', 'longitude'])
+        coords = list(zip(valid['latitude'], valid['longitude']))
         distances = [
             geodesic(coords[i], coords[i + 1]).meters
             for i in range(len(coords) - 1)
         ]
 
         # Calculate speeds using time differences
-        time_diffs = np.diff(self.df['datetime'].astype(np.int64)) / 1e9  # Convert to seconds
+        time_diffs = np.diff(valid['datetime'].astype(np.int64)) / 1e9  # Convert to seconds
         speeds = [d / t for d, t in zip(distances, time_diffs) if t > 0]
 
         return {

--- a/tests/test_analytics_aggregation.py
+++ b/tests/test_analytics_aggregation.py
@@ -9,16 +9,17 @@ from campaign_reader.analytics.aggregation import AnalyticsAggregator
 
 @pytest.fixture
 def sample_analytics_df():
-    """Create a sample DataFrame for testing."""
-    base_time = datetime(2024, 1, 1, 12, 0, 0)
+    """Create a sample DataFrame matching the format produced by AnalyticsData.to_dataframe().
+
+    systemTime values are relative seconds from start of recording.
+    """
     data = []
 
     for i in range(10):
-        timestamp = base_time + timedelta(seconds=i)
         data.append({
             'index': i,
-            'systemTime': str(int(timestamp.timestamp() * 1000)),
-            'videoTime': str(i),
+            'systemTime': float(i),  # relative seconds from start
+            'videoTime': float(i),
             'latitude': 44.9553195 + (i * 0.0001),
             'longitude': -93.3773398 + (i * 0.0001),
             'accuracy': 14.813 + (i * 0.1),

--- a/tests/test_analytics_aggregation.py
+++ b/tests/test_analytics_aggregation.py
@@ -85,7 +85,7 @@ def test_motion_stats(sample_analytics_df):
 def test_aggregate_by_interval(sample_analytics_df):
     """Test time-based aggregation."""
     aggregator = AnalyticsAggregator(sample_analytics_df)
-    aggregated = aggregator.aggregate_by_interval('5S')
+    aggregated = aggregator.aggregate_by_interval('5s')
 
     assert isinstance(aggregated, pd.DataFrame)
     assert len(aggregated) == 2  # Should have 2 5-second intervals


### PR DESCRIPTION
## Summary
- **NaN coordinate crash**: `get_spatial_stats()` passed all coordinate pairs to `geodesic()`, including rows with null GPS data, causing a `ValueError`. Fixed by filtering with `dropna()` before computing distances.
- **Datetime unit mismatch**: `_ensure_datetime()` used `unit='ms'` but `to_dataframe()` already converts `systemTime` from epoch milliseconds to relative seconds. This made duration ~1000x too small and speeds wildly inflated. Fixed by changing to `unit='s'`.
- **Test fixture alignment**: Updated test fixture to produce `systemTime` in relative seconds, matching the format `to_dataframe()` actually produces.

## Test plan
- [x] All 30 existing tests pass
- [x] Verified against real campaign data — distance: 464m, speed: 17.7 m/s, duration: 29.4s

🤖 Generated with [Claude Code](https://claude.com/claude-code)